### PR TITLE
Clean Kernal keyboard and mouse code

### DIFF
--- a/kernal/drivers/x16/ps2mouse.s
+++ b/kernal/drivers/x16/ps2mouse.s
@@ -29,6 +29,9 @@ mousey:	.res 2           ;    cur y coordinate
 mousebt:
 	.res 1           ;    cur buttons (1: left, 2: right, 4: third)
 
+I2C_ADDRESS = $42
+I2C_GET_MOUSE_MOVEMENT_OFFSET = $21
+
 .segment "PS2MOUSE"
 
 ; "MOUSE" KERNAL call
@@ -137,8 +140,8 @@ _mouse_scan:
 	bit msepar ; do nothing if mouse is off
 	bpl @a
 	
-	ldx #$42
-	ldy #$21
+	ldx #I2C_ADDRESS
+	ldy #I2C_GET_MOUSE_MOVEMENT_OFFSET
 	jsr i2c_read_first_byte
 	bcs @a ; error
 	bne @b ; no data
@@ -163,8 +166,6 @@ _mouse_scan:
 .endif
 	sta mousebt
 
-	ldx #$42
-	ldy #$21
 	jsr i2c_read_next_byte
 	clc
 	adc mousex
@@ -177,8 +178,6 @@ _mouse_scan:
 :	adc mousex+1
 	sta mousex+1
 
-	ldx #$42
-	ldy #$21
 	jsr i2c_read_next_byte
 	pha                     ; Push low 8 bits onto stack
 	jsr i2c_read_stop       ; Stop I2C transfer


### PR DESCRIPTION
This PR contains some clean-up for the Kernal keyboard and mouse code that you could consider.

In ps2kbd.s two I2C constants are defined and used in the code:

I2C_ADDRESS = $42
I2C_GET_SCANCODE_OFFSET = $07

The function receive_scancode could be simplified a bit as we converted back to using i2c_read_byte instead of i2c_read_first_byte+i2c_read_next_byte

In ps2mouse.s two constants are defined in the same way:

I2C_ADDRESS = $42
I2C_GET_MOUSE_MOVEMENT_OFFSET = $21

Before calling i2c_read_next_byte the unnecessary setting of X and Y values are deleted.

As I have no means of testing this code - other than that it compiles - check that the mouse and keyboard still works :-)